### PR TITLE
v0.21.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches:
       - main
-      - dev
+      - develop
 
 jobs:
   test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ '3.9' , '3.10', '3.11', '3.12']
+        python-version: [ '3.9' , '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - name: Checkout repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add comparison method to LangString to allow comparison like "a thing" == LangString("a thing", "en")
 - Allowing multiple labels in multiple languages for Thing objects
+- Add support for YAML export
 
 ## v0.20.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add comparison method to LangString to allow comparison like "a thing" == LangString("a thing", "en")
 - Allowing multiple labels in multiple languages for Thing objects
 - Add support for YAML export
+- Added `schema:about` to Thing
 
 ## v0.20.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.20.1
+## v0.21.0
 
 - Add comparison method to LangString to allow comparison like "a thing" == LangString("a thing", "en")
 - Allowing multiple labels in multiple languages for Thing objects

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.20.1
+
+- Add comparison method to LangString to allow comparison like "a thing" == LangString("a thing", "en")
+
 ## v0.20.0
 
 - TTL serialization now treats IRIs correctly, i.e., they are not enclosed in `<...>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Allowing multiple labels in multiple languages for Thing objects
 - Add support for YAML export
 - Added property `schema:about` to Thing
+- support python versions up to 3.14
 
 ## v0.20.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.20.1
 
 - Add comparison method to LangString to allow comparison like "a thing" == LangString("a thing", "en")
+- Allowing multiple labels in multiple languages for Thing objects
 
 ## v0.20.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Add support for YAML export
 - Added property `schema:about` to Thing
 - support python versions up to 3.14
+- Control string representation of LangString via config `show_lang_in_str`. It allows to control whether
+  `LangString("text", "en")` is represented as `text@en` or just `text` in the `__str__`
 
 ## v0.20.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Add comparison method to LangString to allow comparison like "a thing" == LangString("a thing", "en")
 - Allowing multiple labels in multiple languages for Thing objects
 - Add support for YAML export
-- Added `schema:about` to Thing
+- Added property `schema:about` to Thing
 
 ## v0.20.0
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ authors:
     given-names: "Matthias"
     orcid: "https://orcid.org/0000-0001-8729-0482"
 title: "Ontolutils - Object-oriented Things"
-version: 0.20.0
-doi: 10.5281/zenodo.16887324
-date-released: 2025-10-05
+version: 0.21.0
+doi: 10.5281/zenodo.17303372
+date-released: 2025-10-09
 url: "https://github.com/matthiasprobst/ontology-utils"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ the JSON-LD file yourself is too cumbersome *and* you want validation of the par
 lets you design classes, which describe ontology classes like this:
 
 ```python
+import rdflib
 from pydantic import EmailStr, Field
 from pydantic import HttpUrl, model_validator
 
@@ -50,15 +51,19 @@ class Person(Thing):
         return as_id(self, "orcidId")
 
 
-p = Person(id="https://orcid.org/0000-0001-8729-0482",
-           firstName='Matthias', last_name='Probst')
+p = Person(
+    id="https://orcid.org/0000-0001-8729-0482",
+    label=rdflib.Literal("The creator of this package", lang="en"),
+    firstName='Matthias',
+    last_name='Probst'
+)
 # as we have set an alias, we can also use "lastName":
 p = Person(id="https://orcid.org/0000-0001-8729-0482",
            firstName='Matthias', lastName='Probst')
 # The jsonld representation of the object will be the same in both cases:
 json_ld_serialization = p.model_dump_jsonld()
 # Alternatively use
-serialized_str = p.serialize(format="json-ld") # or "ttl", "n3", "nt", "xml"
+serialized_str = p.serialize(format="json-ld")  # or "ttl", "n3", "nt", "xml"
 ```
 
 The result of the serialization is shown below:
@@ -68,6 +73,7 @@ The result of the serialization is shown below:
   "@context": {
     "owl": "http://www.w3.org/2002/07/owl#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "schema": "http://schema.org/",
     "prov": "https://www.w3.org/ns/prov#",
     "foaf": "https://xmlns.com/foaf/0.1/",
     "m4i": "http://w3id.org/nfdi4ing/metadata4ing#"

--- a/codemeta.json
+++ b/codemeta.json
@@ -4,7 +4,7 @@
   "license": "https://spdx.org/licenses/MIT",
   "codeRepository": "git+https://github.com/matthiasprobst/ontology-utils",
   "name": "ontolutils",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "Utility library for the work with ontologies.",
   "programmingLanguage": [
     "Python 3",

--- a/codemeta.json
+++ b/codemeta.json
@@ -4,7 +4,7 @@
   "license": "https://spdx.org/licenses/MIT",
   "codeRepository": "git+https://github.com/matthiasprobst/ontology-utils",
   "name": "ontolutils",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "description": "Utility library for the work with ontologies.",
   "programmingLanguage": [
     "Python 3",

--- a/docs/userguide/classes.rst
+++ b/docs/userguide/classes.rst
@@ -119,6 +119,7 @@ The return value is a JSON-LD string:
             "owl": "http://www.w3.org/2002/07/owl#",
             "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
             "prov": "http://www.w3.org/ns/prov#",
+            "schema": "https://schema.org/",
             "foaf": "http://xmlns.com/foaf/0.1/"
         },
         "@type": "prov:Person",
@@ -151,6 +152,7 @@ The return value is a JSON-LD string:
             "owl": "http://www.w3.org/2002/07/owl#",
             "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
             "prov": "http://www.w3.org/ns/prov#",
+            "schema": "https://schema.org/",
             "foaf": "http://xmlns.com/foaf/0.1/",
             "ex": "https://example.org/"
         },

--- a/ontolutils/__init__.py
+++ b/ontolutils/__init__.py
@@ -3,7 +3,7 @@ import logging
 
 from ._cfg import set_config, get_config
 from ._version import __version__
-from .classes import Thing, get_urirefs, get_namespaces, as_id, build, Property
+from .classes import Thing, LangString, get_urirefs, get_namespaces, as_id, build, Property
 from .classes import namespaces, urirefs
 from .classes import query, dquery, URIValue
 from .classes.utils import merge_jsonld
@@ -31,6 +31,7 @@ def set_logging_level(level: str):
 set_logging_level(DEFAULT_LOGGING_LEVEL)
 
 __all__ = ['Thing',
+           'LangString',
            '__version__',
            'namespaces',
            'urirefs',

--- a/ontolutils/_cfg.py
+++ b/ontolutils/_cfg.py
@@ -2,9 +2,11 @@ from typing import Dict
 
 CONFIG = {
     'blank_id_generator': None,
+    'show_lang_in_str': True
 }
 _VALIDATORS = {
     'blank_id_generator': lambda x: callable(x) or x is None,
+    'show_lang_in_str': lambda x: isinstance(x, bool) or x is None,
 }
 
 

--- a/ontolutils/classes/decorator.py
+++ b/ontolutils/classes/decorator.py
@@ -30,6 +30,7 @@ def _is_http_url(url: str) -> bool:
         return False
     return True
 
+
 def _add_namesapces(cls, namespaces: Dict):
     for k, v in namespaces.items():
         NamespaceManager[cls][k] = str(HttpUrl(v))

--- a/ontolutils/classes/thing.py
+++ b/ontolutils/classes/thing.py
@@ -9,6 +9,7 @@ from typing import Dict, Union, Optional, Any, List, Type
 from urllib.parse import urlparse
 
 import rdflib
+import yaml
 from pydantic import AnyUrl, HttpUrl, FileUrl, BaseModel, ConfigDict, Field, field_validator, model_validator
 from pydantic import field_serializer
 from rdflib.plugins.shared.jsonld.context import Context
@@ -199,6 +200,13 @@ class LangString(BaseModel):
         if isinstance(other, str):
             return self.value == self.value
         raise TypeError(f"Cannot compare LangString with {type(other)}")
+
+
+def langstring_representer(dumper, data):
+    return dumper.represent_scalar('tag:yaml.org,2002:str', str(data))
+
+
+yaml.add_representer(LangString, langstring_representer)
 
 
 def serialize_lang_str_field(lang_str: LangString):

--- a/ontolutils/classes/thing.py
+++ b/ontolutils/classes/thing.py
@@ -182,8 +182,13 @@ class LangString(BaseModel):
 
         return v
 
-    def __str__(self):
-        return f"{self.value}@{self.lang}" if self.lang else self.value
+    def __str__(self, show_lang: bool = None):
+        if show_lang is None:
+            show_lang = get_config("show_lang_in_str")
+        if self.lang and show_lang:
+            return f"{self.value}@{self.lang}"
+        return f"{self.value}" if self.lang else str(self.value)
+
 
     def to_dict(self):
         return {"value": self.value, "lang": self.lang}

--- a/ontolutils/classes/thing.py
+++ b/ontolutils/classes/thing.py
@@ -172,12 +172,13 @@ class LangString(BaseModel):
         if isinstance(v, dict):
             return v
 
-        # if isinstance(v, str):
-        #     return {"value": v}
-
         if isinstance(v, str):
             value, lang = _split_value_lang(v)
             return {"value": value, "lang": lang}
+
+        if isinstance(v, list):
+            return [cls.model_validate(_v) for _v in v]
+
         raise TypeError("LangString must be a str, dict, rdflib.Literal or LangString instance")
 
     def __str__(self):
@@ -263,7 +264,7 @@ class Thing(ThingModel):
 
     """
     id: Optional[Union[str, HttpUrl, FileUrl, BlankNodeType, None]] = Field(default_factory=build_blank_id)  # @id
-    label: Optional[LangString] = None  # rdfs:label
+    label: Optional[Union[LangString, List[LangString]]] = None  # rdfs:label
     relation: Optional[Union[str, HttpUrl, FileUrl, BlankNodeType, ThingModel]] = None
     closeMatch: Optional[Union[str, HttpUrl, FileUrl, BlankNodeType, ThingModel]] = None
     exactMatch: Optional[Union[str, HttpUrl, FileUrl, BlankNodeType, ThingModel]] = None
@@ -452,6 +453,8 @@ class Thing(ThingModel):
             """
             if isinstance(obj, (int, str, float, bool)):
                 return obj
+            if isinstance(obj, LangString):
+                return serialize_lang_str_field(obj)
             if isinstance(obj, datetime):
                 return obj.isoformat()
 

--- a/ontolutils/classes/thing.py
+++ b/ontolutils/classes/thing.py
@@ -148,6 +148,7 @@ def _split_value_lang(s: str) -> tuple[str, Optional[str]]:
 
 
 class LangString(BaseModel):
+    """Language-String"""
     value: str
     lang: Optional[str] = None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pydantic[email]>=2.8.2
 python-dateutil>=2.9.0
 requests>=2.32.3
 appdirs>=1.4.4
+PyYAML>=6.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ontolutils
-version = 0.20.0
+version = 0.20.1
 author = Matthias Probst
 author_email = matthias.probst@kit.edu
 description = Utility library for the work with ontologies.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ontolutils
-version = 0.20.1
+version = 0.21.0
 author = Matthias Probst
 author_email = matthias.probst@kit.edu
 description = Utility library for the work with ontologies.

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,13 +12,15 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Development Status :: 4 - Beta
 
 [options]
 packages = find:
-python_requires = >=3.9, <3.13
+python_requires = >=3.9, <3.15
 include_package_data = True
 install_requires =
     rdflib>=7.0.0
@@ -26,6 +28,7 @@ install_requires =
     python-dateutil>=2.9.0
     requests>=2.32.3
     appdirs>=1.4.4
+    PyYAML>=6.0
 
 [options.extras_require]
 test =

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -600,7 +600,7 @@ class TestNamespaces(unittest.TestCase):
                  affiliation='schema:affiliation')
         class Person(Agent):
             firstName: str = None
-            affiliation: Organization = None
+            affiliation: Union[str, Organization] = None
 
         person = Person(
             label='Person 1',
@@ -615,6 +615,13 @@ class TestNamespaces(unittest.TestCase):
         self.assertEqual(jsonld_dict['schema:affiliation']['rdfs:label'], 'Organization 1')
         self.assertEqual(jsonld_dict['rdfs:label'], 'Person 1')
         self.assertEqual(jsonld_dict['@type'], 'foaf:Person')
+
+        person = Person(
+            label='Person 1',
+            affiliation='schema:Organization/123',
+        )
+
+        print(person.serialize("ttl"))
 
     def test_prov(self):
         @namespaces(prov="https://www.w3.org/ns/prov#",

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -243,8 +243,11 @@ class TestNamespaces(unittest.TestCase):
     def test_language_string1(self):
         self.assertEqual("a thing", LangString(value="a thing", lang="en").value)
         self.assertEqual("a thing", LangString(value="a thing").value)
+        self.assertEqual("a thing", LangString(value="a thing"))
+        self.assertEqual("a thing", LangString(value="a thing", lang="en"))
+        self.assertNotEqual("a thing", LangString(value="another thing").value)
         self.assertNotEqual("a thing", LangString(value="another thing", lang="en").value)
-
+        self.assertNotEqual(LangString(value="Hello", lang="en"), "Hello@fr")
         thing_en = Thing(label=LangString(value='a thing.', lang='en'))
         ttl = thing_en.model_dump_ttl()
         self.assertEqual(ttl, """@prefix owl: <http://www.w3.org/2002/07/owl#> .
@@ -1195,36 +1198,36 @@ agents:123 a foaf:Agent ;
             """
             name: str = Field(default=None, alias="lastName")  # name is synonymous to lastName
 
-#         with self.assertRaises(ValidationError):
-#             Agent(
-#                 name="John Doe",
-#                 about="A person"
-#             )
-#         p = Agent(
-#             name="John Doe",
-#             about="http://example.org/123"
-#         )
-#         p = Agent(
-#             name="John Doe",
-#             about=["http://example.org/123", "http://example.org/456"]
-#         )
-#         p = Agent(
-#             name="John Doe",
-#             about=["http://example.org/123", Thing(id="http://example.org/456")]
-#         )
-#         ttl = p.model_dump_ttl()
-#         self.assertEqual(ttl, """@prefix foaf: <http://xmlns.com/foaf/0.1/> .
-# @prefix owl: <http://www.w3.org/2002/07/owl#> .
-# @prefix schema: <https://schema.org/> .
-#
-# <http://example.org/456> a owl:Thing .
-#
-# [] a foaf:Agent ;
-#     foaf:lastName "John Doe" ;
-#     schema:about <http://example.org/456>,
-#         "http://example.org/123" .
-#
-# """)
+        #         with self.assertRaises(ValidationError):
+        #             Agent(
+        #                 name="John Doe",
+        #                 about="A person"
+        #             )
+        #         p = Agent(
+        #             name="John Doe",
+        #             about="http://example.org/123"
+        #         )
+        #         p = Agent(
+        #             name="John Doe",
+        #             about=["http://example.org/123", "http://example.org/456"]
+        #         )
+        #         p = Agent(
+        #             name="John Doe",
+        #             about=["http://example.org/123", Thing(id="http://example.org/456")]
+        #         )
+        #         ttl = p.model_dump_ttl()
+        #         self.assertEqual(ttl, """@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+        # @prefix owl: <http://www.w3.org/2002/07/owl#> .
+        # @prefix schema: <https://schema.org/> .
+        #
+        # <http://example.org/456> a owl:Thing .
+        #
+        # [] a foaf:Agent ;
+        #     foaf:lastName "John Doe" ;
+        #     schema:about <http://example.org/456>,
+        #         "http://example.org/123" .
+        #
+        # """)
         p = Agent(
             name="John Doe",
             about=SCHEMA.about

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -227,7 +227,7 @@ class TestNamespaces(unittest.TestCase):
         thing2 = Thing(label='Thing 2', id='https://example.com/thing2')
         self.assertTrue(thing1 < thing2)
 
-    def test_language(self):
+    def test_language_string1(self):
         self.assertEqual("a thing", LangString(value="a thing", lang="en").value)
         self.assertEqual("a thing", LangString(value="a thing").value)
         self.assertNotEqual("a thing", LangString(value="another thing", lang="en").value)
@@ -241,6 +241,8 @@ class TestNamespaces(unittest.TestCase):
     rdfs:label "a thing."@en .
 
 """)
+
+    def test_language_string2(self):
         thing_en = Thing(
             label=[LangString(value='a thing.', lang='en'),
                    LangString(value='ein Ding.', lang='de'),]
@@ -254,7 +256,7 @@ class TestNamespaces(unittest.TestCase):
         "a thing."@en .
 
 """)
-
+    def test_language_string3(self):
         thing_en = Thing(label="deutsch@de")
         ttl = thing_en.model_dump_ttl()
         self.assertEqual(ttl, """@prefix owl: <http://www.w3.org/2002/07/owl#> .
@@ -275,14 +277,18 @@ class TestNamespaces(unittest.TestCase):
         #     rdfs:label "2025-01-01"^^xsd:date .
         #
         # """)
-
-        thing_en = Thing(label='2025-01-01')
+    def test_language_string4(self):
+        thing_en = Thing(label=[
+            "a thing.@en",
+            "ein Ding@de"
+        ])
         ttl = thing_en.model_dump_ttl()
         self.assertEqual(ttl, """@prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
 [] a owl:Thing ;
-    rdfs:label "2025-01-01" .
+    rdfs:label "ein Ding"@de,
+        "a thing."@en .
 
 """)
 

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -15,6 +15,7 @@ from rdflib.plugins.shared.jsonld.context import Context
 from typing_extensions import Annotated
 
 import ontolutils
+from ontolutils import SCHEMA
 from ontolutils import Thing, urirefs, namespaces, build, Property
 from ontolutils import as_id
 from ontolutils import get_urirefs, get_namespaces, set_config
@@ -1187,33 +1188,47 @@ agents:123 a foaf:Agent ;
             """
             name: str = Field(default=None, alias="lastName")  # name is synonymous to lastName
 
-        with self.assertRaises(ValidationError):
-            Agent(
-                name="John Doe",
-                about="A person"
-            )
+#         with self.assertRaises(ValidationError):
+#             Agent(
+#                 name="John Doe",
+#                 about="A person"
+#             )
+#         p = Agent(
+#             name="John Doe",
+#             about="http://example.org/123"
+#         )
+#         p = Agent(
+#             name="John Doe",
+#             about=["http://example.org/123", "http://example.org/456"]
+#         )
+#         p = Agent(
+#             name="John Doe",
+#             about=["http://example.org/123", Thing(id="http://example.org/456")]
+#         )
+#         ttl = p.model_dump_ttl()
+#         self.assertEqual(ttl, """@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+# @prefix owl: <http://www.w3.org/2002/07/owl#> .
+# @prefix schema: <https://schema.org/> .
+#
+# <http://example.org/456> a owl:Thing .
+#
+# [] a foaf:Agent ;
+#     foaf:lastName "John Doe" ;
+#     schema:about <http://example.org/456>,
+#         "http://example.org/123" .
+#
+# """)
         p = Agent(
             name="John Doe",
-            about="http://example.org/123"
-        )
-        p = Agent(
-            name="John Doe",
-            about=["http://example.org/123", "http://example.org/456"]
-        )
-        p = Agent(
-            name="John Doe",
-            about=["http://example.org/123", Thing(id="http://example.org/456")]
+            about=SCHEMA.about
         )
         ttl = p.model_dump_ttl()
+        print(ttl)
         self.assertEqual(ttl, """@prefix foaf: <http://xmlns.com/foaf/0.1/> .
-@prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix schema: <https://schema.org/> .
-
-<http://example.org/456> a owl:Thing .
 
 [] a foaf:Agent ;
     foaf:lastName "John Doe" ;
-    schema:about <http://example.org/456>,
-        "http://example.org/123" .
+    schema:about schema:about .
 
 """)

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -228,6 +228,17 @@ class TestNamespaces(unittest.TestCase):
         thing2 = Thing(label='Thing 2', id='https://example.com/thing2')
         self.assertTrue(thing1 < thing2)
 
+    def test_language_string0(self):
+        thing_en = Thing(label=rdflib.Literal(lexical_or_value='a thing.', lang='en'))
+        ttl = thing_en.model_dump_ttl()
+        self.assertEqual(ttl, """@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+[] a owl:Thing ;
+    rdfs:label "a thing."@en .
+
+""")
+
     def test_language_string1(self):
         self.assertEqual("a thing", LangString(value="a thing", lang="en").value)
         self.assertEqual("a thing", LangString(value="a thing").value)
@@ -307,6 +318,32 @@ class TestNamespaces(unittest.TestCase):
         thing = Thing(label='Thing 1')
         self.assertEqual(thing._repr_html_(), f'Thing(id={thing.id}, label=Thing 1)')
 
+    def test_serialize_date(self):
+        @namespaces(dcterms="http://purl.org/dc/terms/")
+        @urirefs(MyThing='foaf:MyThing',
+                 created='dcterms:created')
+        class MyThing(Thing):
+            created: datetime.datetime = None
+
+        mything = MyThing(created=datetime.datetime(year=2025, month=10, day=1, hour=12, minute=30))
+        ttl = mything.serialize("ttl")
+        self.assertEqual(ttl, """@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+[] a <foaf:MyThing> ;
+    dcterms:created "2025-10-01T12:30:00"^^xsd:dateTime .
+
+""")
+        mything = MyThing(created=datetime.datetime(year=2025, month=10, day=1))
+        ttl = mything.serialize("ttl")
+        self.assertEqual(ttl, """@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+[] a <foaf:MyThing> ;
+    dcterms:created "2025-10-01"^^xsd:date .
+
+""")
+
     def test_thing_get_jsonld_dict(self):
         with self.assertRaises(TypeError):
             _ = Thing(id=1, label='Thing 1')
@@ -329,6 +366,7 @@ class TestNamespaces(unittest.TestCase):
             thing_dict['@context'],
             {'owl': 'http://www.w3.org/2002/07/owl#',
              'rdfs': 'http://www.w3.org/2000/01/rdf-schema#',
+             'schema': 'https://schema.org/',
              'skos': 'http://www.w3.org/2004/02/skos/core#',
              'dcterms': 'http://purl.org/dc/terms/'
              }
@@ -634,6 +672,7 @@ class TestNamespaces(unittest.TestCase):
                 "prov": "https://www.w3.org/ns/prov#",
                 "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
                 "dcterms": "http://purl.org/dc/terms/",
+                'schema': 'https://schema.org/',
                 "skos": "http://www.w3.org/2004/02/skos/core#",
                 "foaf": "http://xmlns.com/foaf/0.1/",
             },
@@ -666,6 +705,7 @@ class TestNamespaces(unittest.TestCase):
                 "owl": "http://www.w3.org/2002/07/owl#",
                 "prov": "https://www.w3.org/ns/prov#",
                 "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+                'schema': 'https://schema.org/',
                 "dcterms": "http://purl.org/dc/terms/",
                 "skos": "http://www.w3.org/2004/02/skos/core#",
                 "foaf": "http://xmlns.com/foaf/0.1/",
@@ -793,10 +833,11 @@ class TestNamespaces(unittest.TestCase):
         self.assertDictEqual(mt.urirefs, get_urirefs(Thing))
         self.assertDictEqual(mt.urirefs,
                              {'Thing': 'owl:Thing', 'closeMatch': 'skos:closeMatch', 'exactMatch': 'skos:exactMatch',
-                              'label': 'rdfs:label', 'relation': 'dcterms:relation'})
+                              'label': 'rdfs:label', 'about': 'schema:about', 'relation': 'dcterms:relation'})
         self.assertDictEqual(mt.namespaces, get_namespaces(Thing))
         self.assertDictEqual(mt.namespaces, {'owl': 'http://www.w3.org/2002/07/owl#',
                                              'rdfs': 'http://www.w3.org/2000/01/rdf-schema#',
+                                             'schema': 'https://schema.org/',
                                              'skos': 'http://www.w3.org/2004/02/skos/core#',
                                              'dcterms': 'http://purl.org/dc/terms/'})
 
@@ -814,6 +855,7 @@ class TestNamespaces(unittest.TestCase):
             "@context": {
                 "owl": "http://www.w3.org/2002/07/owl#",
                 "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+                'schema': 'https://schema.org/',
                 "dcterms": "http://purl.org/dc/terms/",
                 "skos": "http://www.w3.org/2004/02/skos/core#",
                 "foaf": "http://xmlns.com/foaf/0.1/"
@@ -1131,3 +1173,47 @@ agents:123 a foaf:Agent ;
         org1 = Organization(members=p1)
         org2 = Organization(members=p2.map(Person1))
         # org3 = Organization(members=[p1, p2])
+
+    def test_about(self):
+        @namespaces(foaf="http://xmlns.com/foaf/0.1/")
+        @urirefs(Agent='foaf:Agent',
+                 name='foaf:lastName')
+        class Agent(Thing):
+            """Pydantic Model for http://xmlns.com/foaf/0.1/Agent
+            Parameters
+            ----------
+            mbox: EmailStr = None
+                Email address (foaf:mbox)
+            """
+            name: str = Field(default=None, alias="lastName")  # name is synonymous to lastName
+
+        with self.assertRaises(ValidationError):
+            Agent(
+                name="John Doe",
+                about="A person"
+            )
+        p = Agent(
+            name="John Doe",
+            about="http://example.org/123"
+        )
+        p = Agent(
+            name="John Doe",
+            about=["http://example.org/123", "http://example.org/456"]
+        )
+        p = Agent(
+            name="John Doe",
+            about=["http://example.org/123", Thing(id="http://example.org/456")]
+        )
+        ttl = p.model_dump_ttl()
+        self.assertEqual(ttl, """@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix schema: <https://schema.org/> .
+
+<http://example.org/456> a owl:Thing .
+
+[] a foaf:Agent ;
+    foaf:lastName "John Doe" ;
+    schema:about <http://example.org/456>,
+        "http://example.org/123" .
+
+""")

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -7,6 +7,7 @@ from typing import Optional, List, Union
 
 import pydantic
 import rdflib
+import yaml
 from pydantic import EmailStr, model_validator
 from pydantic import ValidationError
 from pydantic import field_validator, Field
@@ -245,7 +246,7 @@ class TestNamespaces(unittest.TestCase):
     def test_language_string2(self):
         thing_en = Thing(
             label=[LangString(value='a thing.', lang='en'),
-                   LangString(value='ein Ding.', lang='de'),]
+                   LangString(value='ein Ding.', lang='de'), ]
         )
         ttl = thing_en.model_dump_ttl()
         self.assertEqual(ttl, """@prefix owl: <http://www.w3.org/2002/07/owl#> .
@@ -256,6 +257,7 @@ class TestNamespaces(unittest.TestCase):
         "a thing."@en .
 
 """)
+
     def test_language_string3(self):
         thing_en = Thing(label="deutsch@de")
         ttl = thing_en.model_dump_ttl()
@@ -277,6 +279,7 @@ class TestNamespaces(unittest.TestCase):
         #     rdfs:label "2025-01-01"^^xsd:date .
         #
         # """)
+
     def test_language_string4(self):
         thing_en = Thing(label=[
             "a thing.@en",
@@ -291,6 +294,14 @@ class TestNamespaces(unittest.TestCase):
         "a thing."@en .
 
 """)
+
+    def test_lang_string_yaml_support(self):
+        ls = LangString(value="hallo", lang="de")
+        with open("output.yaml", "w", encoding="utf-8") as f:
+            yaml.dump(ls, f, allow_unicode=True)
+        with open("output.yaml", "r", encoding="utf-8") as f:
+            ls2 = yaml.load(f, Loader=yaml.Loader)
+        self.assertEqual(ls, ls2)
 
     def test__repr_html_(self):
         thing = Thing(label='Thing 1')

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -241,22 +241,31 @@ class TestNamespaces(unittest.TestCase):
 """)
 
     def test_language_string1(self):
+        self.assertNotEqual("x", LangString(value='upward', lang=None))
         self.assertEqual("a thing", LangString(value="a thing", lang="en").value)
         self.assertEqual("a thing", LangString(value="a thing").value)
         self.assertEqual("a thing", LangString(value="a thing"))
         self.assertEqual("a thing", LangString(value="a thing", lang="en"))
         self.assertNotEqual("a thing", LangString(value="another thing").value)
         self.assertNotEqual("a thing", LangString(value="another thing", lang="en").value)
+
         self.assertNotEqual(LangString(value="Hello", lang="en"), "Hello@fr")
         thing_en = Thing(label=LangString(value='a thing.', lang='en'))
-        ttl = thing_en.model_dump_ttl()
-        self.assertEqual(ttl, """@prefix owl: <http://www.w3.org/2002/07/owl#> .
+        with set_config(show_lang_in_str=True):
+            ttl = thing_en.model_dump_ttl()
+            self.assertEqual(ttl, """@prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
 [] a owl:Thing ;
     rdfs:label "a thing."@en .
 
 """)
+        with set_config(show_lang_in_str=False):
+            self.assertEqual(str(LangString(value="a thing", lang="en")), "a thing")
+        with set_config(show_lang_in_str=True):
+            self.assertEqual(str(LangString(value="a thing", lang="en")), "a thing@en")
+        with set_config(show_lang_in_str=True):
+            self.assertEqual(str(LangString(value="a thing")), "a thing")
 
     def test_language_string2(self):
         thing_en = Thing(

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -241,6 +241,19 @@ class TestNamespaces(unittest.TestCase):
     rdfs:label "a thing."@en .
 
 """)
+        thing_en = Thing(
+            label=[LangString(value='a thing.', lang='en'),
+                   LangString(value='ein Ding.', lang='de'),]
+        )
+        ttl = thing_en.model_dump_ttl()
+        self.assertEqual(ttl, """@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+[] a owl:Thing ;
+    rdfs:label "ein Ding."@de,
+        "a thing."@en .
+
+""")
 
         thing_en = Thing(label="deutsch@de")
         ttl = thing_en.model_dump_ttl()

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -5,7 +5,6 @@ import unittest
 from itertools import count
 from typing import Optional, List, Union
 
-from rdflib.namespace import XSD
 import pydantic
 import rdflib
 from pydantic import EmailStr, model_validator
@@ -229,17 +228,17 @@ class TestNamespaces(unittest.TestCase):
         self.assertTrue(thing1 < thing2)
 
     def test_language(self):
+        self.assertEqual("a thing", LangString(value="a thing", lang="en").value)
+        self.assertEqual("a thing", LangString(value="a thing").value)
+        self.assertNotEqual("a thing", LangString(value="another thing", lang="en").value)
 
-        # with self.assertRaises(ValueError):
-        #     LangString(value='invalid', lang='en', datatype=XSD.date)
-
-        thing_en = Thing(label=LangString(value='a thing', lang='en'))
+        thing_en = Thing(label=LangString(value='a thing.', lang='en'))
         ttl = thing_en.model_dump_ttl()
         self.assertEqual(ttl, """@prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
 [] a owl:Thing ;
-    rdfs:label "a thing"@en .
+    rdfs:label "a thing."@en .
 
 """)
 
@@ -253,16 +252,16 @@ class TestNamespaces(unittest.TestCase):
 
 """)
 
-#         thing_en = Thing(label=LangString(value='2025-01-01', datatype=XSD.date))
-#         ttl = thing_en.model_dump_ttl()
-#         self.assertEqual(ttl, """@prefix owl: <http://www.w3.org/2002/07/owl#> .
-# @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-# @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-#
-# [] a owl:Thing ;
-#     rdfs:label "2025-01-01"^^xsd:date .
-#
-# """)
+        #         thing_en = Thing(label=LangString(value='2025-01-01', datatype=XSD.date))
+        #         ttl = thing_en.model_dump_ttl()
+        #         self.assertEqual(ttl, """@prefix owl: <http://www.w3.org/2002/07/owl#> .
+        # @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        # @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+        #
+        # [] a owl:Thing ;
+        #     rdfs:label "2025-01-01"^^xsd:date .
+        #
+        # """)
 
         thing_en = Thing(label='2025-01-01')
         ttl = thing_en.model_dump_ttl()

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -3,6 +3,7 @@ import json
 import unittest
 from typing import List, Union
 
+import rdflib
 from pydantic import EmailStr
 from pydantic import Field
 from pydantic import HttpUrl, model_validator
@@ -39,8 +40,12 @@ class TestReadmeCode(unittest.TestCase):
             def _change_id(self):
                 return as_id(self, "orcidId")
 
-        Person(id="https://orcid.org/0000-0001-8729-0482",
-               firstName='Matthias', last_name='Probst')
+        p = Person(
+            id="https://orcid.org/0000-0001-8729-0482",
+            label=rdflib.Literal("The creator of this package", lang="en"),
+            firstName='Matthias',
+            last_name='Probst'
+        )
         # as we have set an alias, we can also use "lastName":
         p = Person(id="https://orcid.org/0000-0001-8729-0482",
                    firstName='Matthias', lastName='Probst')
@@ -52,6 +57,7 @@ class TestReadmeCode(unittest.TestCase):
     "owl": "http://www.w3.org/2002/07/owl#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
     "dcterms": "http://purl.org/dc/terms/",
+    "schema": "https://schema.org/",
     "skos": "http://www.w3.org/2004/02/skos/core#",
     "prov": "https://www.w3.org/ns/prov#",
     "foaf": "http://xmlns.com/foaf/0.1/",
@@ -117,6 +123,7 @@ class TestReadmeCode(unittest.TestCase):
         "skos": "http://www.w3.org/2004/02/skos/core#",
         "prov": "http://www.w3.org/ns/prov#",
         "foaf": "http://xmlns.com/foaf/0.1/",
+        "schema": "https://schema.org/",
         "ex": "https://example.org/"
     },
     "@type": "prov:Person",


### PR DESCRIPTION
- Add comparison method to LangString to allow comparison like "a thing" == LangString("a thing", "en")
- Allowing multiple labels in multiple languages for Thing objects
- Add support for YAML export
- Added property `schema:about` to Thing
- support python versions up to 3.14
- Control string representation of LangString via config `show_lang_in_str`. It allows to control whether
  `LangString("text", "en")` is represented as `text@en` or just `text` in the `__str__`
